### PR TITLE
Move emailAgent and add integration test

### DIFF
--- a/src/openai/emailAgent.ts
+++ b/src/openai/emailAgent.ts
@@ -1,7 +1,7 @@
 import { google } from 'googleapis';
 import OpenAI from 'openai';
-import config from './loadConfig';
-import { authorizeGmail } from './utils/authorizeGmail';
+import config from '../loadConfig';
+import { authorizeGmail } from '../utils/authorizeGmail';
 
 function decodeBase64(data: string): string {
   const normalized = data.replace(/-/g, '+').replace(/_/g, '/');
@@ -61,7 +61,7 @@ export async function runEmailAgent(messageId: string, userEmail?: string): Prom
 if (require.main === module) {
   const id = process.argv[2];
   if (!id) {
-    console.error('Usage: node dist/src/emailAgent.js <messageId>');
+    console.error('Usage: node dist/src/openai/emailAgent.js <messageId>');
     process.exit(1);
   }
   runEmailAgent(id)

--- a/test/emailAgent.test.ts
+++ b/test/emailAgent.test.ts
@@ -1,0 +1,22 @@
+import 'dotenv/config';
+import { runEmailAgent } from '../src/openai/emailAgent';
+
+describe('runEmailAgent integration', () => {
+  const messageId = process.env.EMAIL_AGENT_TEST_MESSAGE_ID;
+  const gmailUser = process.env.EMAIL_AGENT_TEST_USER;
+
+  jest.setTimeout(1000 * 60 * 5);
+
+  if (!messageId) {
+    test('skip when no message id provided', () => {
+      console.warn('EMAIL_AGENT_TEST_MESSAGE_ID not set. Skipping test.');
+    });
+    return;
+  }
+
+  test('should return a non-empty response', async () => {
+    const result = await runEmailAgent(messageId, gmailUser);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- move `emailAgent.ts` into `src/openai`
- allow running the email agent in integration test with an optional Gmail message ID

## Testing
- `npm run test:all` *(fails: A jest worker process was terminated)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68482efdcde0832c9d8bbd4f61a0d79b