### PR TITLE
Fix lint issues in email agent and tests

### DIFF
--- a/src/openai/emailAgent.ts
+++ b/src/openai/emailAgent.ts
@@ -9,7 +9,13 @@ function decodeBase64(data: string): string {
     return buff.toString('utf8');
 }
 
-function extractMessageBody(payload: any): string {
+interface GmailMessagePart {
+    mimeType?: string;
+    body?: { data?: string };
+    parts?: GmailMessagePart[];
+}
+
+function extractMessageBody(payload: GmailMessagePart | undefined): string {
     if (!payload) return '';
     if (payload.parts && Array.isArray(payload.parts)) {
         for (const part of payload.parts) {
@@ -58,8 +64,14 @@ export async function runEmailAgent(messageId: string, userEmail?: string): Prom
     const first = messages.data[0];
     let response = '';
     if (first && Array.isArray(first.content)) {
+        interface MessageContent {
+            type: string;
+            text?: { value: string };
+        }
         response = first.content
-            .map((c: any) => (c.type === 'text' && c.text ? c.text.value : ''))
+            .map((c: MessageContent) =>
+                c.type === 'text' && c.text ? c.text.value : ''
+            )
             .join('\n');
     }
     return response;

--- a/test/emailAgent.test.ts
+++ b/test/emailAgent.test.ts
@@ -8,7 +8,7 @@ describe('runEmailAgent integration', () => {
     jest.setTimeout(1000 * 60 * 5);
 
     if (!messageId) {
-        test('skip when no message id provided', () => {
+        test.skip('skip when no message id provided', () => {
             console.warn('EMAIL_AGENT_TEST_MESSAGE_ID not set. Skipping test.');
         });
         return;

--- a/test/runAuth.test.ts
+++ b/test/runAuth.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as assert from 'assert'; // Using Node.js built-in assert module
 import 'dotenv/config'; // To load environment variables if needed
 
-import { authorizeGmail, readTokenData, writeTokenData } from '../src/utils/authorizeGmail';
+import { authorizeGmail, readTokenData } from '../src/utils/authorizeGmail';
 import { OAuth2Client } from 'googleapis-common';
 import originalConfig from '../src/loadConfig'; // Assuming loadConfig.ts exists and exports default
 import { AppConfig } from '../src/types/config'; // Import AppConfig


### PR DESCRIPTION
## Summary
- fix ESLint complaints in `emailAgent.ts`
- skip integration test when the env var is missing
- remove unused import in `runAuth` test

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: cannot find built test files)*

------
https://chatgpt.com/codex/tasks/task_e_68483347f314832ca0cebf60673b2b15